### PR TITLE
add rate limiting to url requests

### DIFF
--- a/sportsipy/fb/roster.py
+++ b/sportsipy/fb/roster.py
@@ -7,7 +7,8 @@ from .league_ids import LEAGUE_IDS
 from pyquery import PyQuery as pq
 from sportsipy.utils import (_get_stats_table,
                              _parse_field,
-                             _remove_html_comment_tags)
+                             _remove_html_comment_tags,
+                             _rate_limit_pq)
 from urllib.error import HTTPError
 
 
@@ -1642,7 +1643,7 @@ class Roster:
         """
         if not doc:
             try:
-                doc = pq(SQUAD_URL % self._squad_id)
+                doc = _rate_limit_pq(SQUAD_URL % self._squad_id)
                 doc = pq(_remove_html_comment_tags(doc))
             except HTTPError:
                 return None

--- a/sportsipy/fb/schedule.py
+++ b/sportsipy/fb/schedule.py
@@ -613,7 +613,7 @@ class Schedule:
         if not doc:
             squad_id = _lookup_team(team_id)
             try:
-                doc = pq(SQUAD_URL % squad_id)
+                doc = utils._rate_limit_pq(SQUAD_URL % squad_id)
             except HTTPError:
                 return
         schedule = utils._get_stats_table(doc, 'table#matchlogs_all')

--- a/sportsipy/mlb/boxscore.py
+++ b/sportsipy/mlb/boxscore.py
@@ -468,8 +468,10 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
-        except HTTPError:
+            url_data = utils._rate_limit_pq(url)
+        except HTTPError as e:
+            print('HTTP Error')
+            print(e)
             return None
         return pq(utils._remove_html_comment_tags(url_data))
 
@@ -1732,7 +1734,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/mlb/roster.py
+++ b/sportsipy/mlb/roster.py
@@ -247,7 +247,7 @@ class Player(AbstractPlayer):
         """
         url = self._build_url()
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1489,7 +1489,7 @@ class Roster:
             Returns a PyQuery object of the team's HTML page.
         """
         try:
-            return pq(url)
+            return utils._rate_limit_pq(url)
         except HTTPError:
             return None
 

--- a/sportsipy/mlb/schedule.py
+++ b/sportsipy/mlb/schedule.py
@@ -492,7 +492,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation,
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation, year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#team_schedule')
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/nba/boxscore.py
+++ b/sportsipy/nba/boxscore.py
@@ -314,7 +314,7 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1644,7 +1644,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/nba/nba_utils.py
+++ b/sportsipy/nba/nba_utils.py
@@ -72,7 +72,7 @@ def _retrieve_all_teams(year, season_file=None):
         # instead.
         if year == 2021:
             try:
-                doc = pq(SEASON_PAGE_URL % year)
+                doc = utils._rate_limit_pq(SEASON_PAGE_URL % year)
             except HTTPError:
                 year = str(int(year) - 1)
         # If stats for the requested season do not exist yet (as is the case

--- a/sportsipy/nba/roster.py
+++ b/sportsipy/nba/roster.py
@@ -235,7 +235,7 @@ class Player(AbstractPlayer):
         """
         url = self._build_url()
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except (HTTPError, ParserError):
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1422,7 +1422,7 @@ class Roster:
             Returns a PyQuery object of the team's HTML page.
         """
         try:
-            return pq(url)
+            return utils._rate_limit_pq(url)
         except HTTPError:
             return None
 
@@ -1535,7 +1535,7 @@ class Roster:
             # be pulled instead.
             if year == 2021:
                 try:
-                    doc = pq(self._create_url(year))
+                    doc = utils._rate_limit_pq(self._create_url(year))
                 except HTTPError:
                     year = str(int(year) - 1)
             # If stats for the requested season do not exist yet (as is the

--- a/sportsipy/nba/schedule.py
+++ b/sportsipy/nba/schedule.py
@@ -435,7 +435,7 @@ class Schedule:
             # be pulled instead.
             if year == 2021:
                 try:
-                    doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
+                    doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation.lower(), year))
                 except HTTPError:
                     year = str(int(year) - 1)
             # If stats for the requested season do not exist yet (as is the
@@ -447,7 +447,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation.lower(),
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation, year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#games')
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/ncaab/boxscore.py
+++ b/sportsipy/ncaab/boxscore.py
@@ -259,7 +259,7 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1702,7 +1702,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/ncaab/conferences.py
+++ b/sportsipy/ncaab/conferences.py
@@ -55,7 +55,7 @@ class Conference:
             A string of the requested year to pull conference information from.
         """
         try:
-            return pq(CONFERENCE_URL % (conference_abbreviation, year))
+            return utils._rate_limit_pq(CONFERENCE_URL % (conference_abbreviation, year))
         except HTTPError:
             return None
 
@@ -184,7 +184,7 @@ class Conferences:
             Returns a PyQuery object of the conference HTML page.
         """
         try:
-            return pq(CONFERENCES_URL % year)
+            return utils._rate_limit_pq(CONFERENCES_URL % year)
         except HTTPError:
             return None
 

--- a/sportsipy/ncaab/rankings.py
+++ b/sportsipy/ncaab/rankings.py
@@ -54,7 +54,7 @@ class Rankings:
             Returns a PyQuery object of the rankings HTML page.
         """
         try:
-            return pq(RANKINGS_URL % year)
+            return utils._rate_limit_pq(RANKINGS_URL % year)
         except HTTPError:
             return None
 

--- a/sportsipy/ncaab/roster.py
+++ b/sportsipy/ncaab/roster.py
@@ -145,7 +145,7 @@ class Player(AbstractPlayer):
         """
         url = PLAYER_URL % self._player_id
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except (HTTPError, ParserError):
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -695,7 +695,7 @@ class Roster:
             Returns a PyQuery object of the team's HTML page.
         """
         try:
-            return pq(url)
+            return utils._rate_limit_pq(url)
         except HTTPError:
             return None
 

--- a/sportsipy/ncaab/schedule.py
+++ b/sportsipy/ncaab/schedule.py
@@ -521,7 +521,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation.lower(),
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#schedule')
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/ncaaf/boxscore.py
+++ b/sportsipy/ncaaf/boxscore.py
@@ -381,7 +381,7 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1287,7 +1287,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/ncaaf/conferences.py
+++ b/sportsipy/ncaaf/conferences.py
@@ -63,7 +63,7 @@ class Conference:
             A string of the requested year to pull conference information from.
         """
         try:
-            return pq(CONFERENCE_URL % (conference_abbreviation, year))
+            return utils._rate_limit_pq(CONFERENCE_URL % (conference_abbreviation, year))
         except (HTTPError, ParserError):
             return None
 
@@ -201,7 +201,7 @@ class Conferences:
             Returns a PyQuery object of the conference HTML page.
         """
         try:
-            return pq(CONFERENCES_URL % year)
+            return utils._rate_limit_pq(CONFERENCES_URL % year)
         except HTTPError:
             return None
 

--- a/sportsipy/ncaaf/rankings.py
+++ b/sportsipy/ncaaf/rankings.py
@@ -54,7 +54,7 @@ class Rankings:
             Returns a PyQuery object of the rankings HTML page.
         """
         try:
-            return pq(RANKINGS_URL % year)
+            return utils._rate_limit_pq(RANKINGS_URL % year)
         except HTTPError:
             return None
 
@@ -269,7 +269,7 @@ class CFPRankings:
             Returns a PyQuery object of the rankings HTML page.
         """
         try:
-            return pq(RANKINGS_URL % year)
+            return utils._rate_limit_pq(RANKINGS_URL % year)
         except HTTPError:
             return None
 

--- a/sportsipy/ncaaf/roster.py
+++ b/sportsipy/ncaaf/roster.py
@@ -170,7 +170,7 @@ class Player(AbstractPlayer):
         """
         url = self._build_url()
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))

--- a/sportsipy/ncaaf/schedule.py
+++ b/sportsipy/ncaaf/schedule.py
@@ -468,7 +468,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation.lower(),
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#schedule')
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/nfl/boxscore.py
+++ b/sportsipy/nfl/boxscore.py
@@ -330,7 +330,7 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         # For NFL, a 404 page doesn't actually raise a 404 error, so it needs
@@ -1558,7 +1558,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/nfl/roster.py
+++ b/sportsipy/nfl/roster.py
@@ -275,7 +275,7 @@ class Player(AbstractPlayer):
         """
         url = self._build_url()
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except (HTTPError, ParserError):
             return None
         # For NFL, a 404 page doesn't actually raise a 404 error, so it needs

--- a/sportsipy/nfl/schedule.py
+++ b/sportsipy/nfl/schedule.py
@@ -703,7 +703,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation.lower(),
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#gamelog%s' % year)
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/nhl/boxscore.py
+++ b/sportsipy/nhl/boxscore.py
@@ -310,7 +310,7 @@ class Boxscore:
         """
         url = BOXSCORE_URL % uri
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))
@@ -1212,7 +1212,7 @@ class Boxscores:
             A PyQuery object containing the HTML contents of the requested
             page.
         """
-        return pq(url)
+        return utils._rate_limit_pq(url)
 
     def _get_boxscore_uri(self, url):
         """

--- a/sportsipy/nhl/roster.py
+++ b/sportsipy/nhl/roster.py
@@ -209,7 +209,7 @@ class Player(AbstractPlayer):
         """
         url = self._build_url()
         try:
-            url_data = pq(url)
+            url_data = utils._rate_limit_pq(url)
         except HTTPError:
             return None
         return pq(utils._remove_html_comment_tags(url_data))

--- a/sportsipy/nhl/schedule.py
+++ b/sportsipy/nhl/schedule.py
@@ -605,7 +605,7 @@ class Schedule:
                utils._url_exists(SCHEDULE_URL % (abbreviation,
                                                  str(int(year) - 1))):
                 year = str(int(year) - 1)
-        doc = pq(SCHEDULE_URL % (abbreviation, year))
+        doc = utils._rate_limit_pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#tm_gamelog_rs')
         if not schedule:
             utils._no_data_found()

--- a/sportsipy/utils.py
+++ b/sportsipy/utils.py
@@ -3,6 +3,7 @@ import requests
 from datetime import datetime
 from lxml.etree import ParserError, XMLSyntaxError
 from pyquery import PyQuery as pq
+import time
 
 
 # {
@@ -22,6 +23,11 @@ SEASON_START_MONTH = {
     'nfl': {'start': 9, 'wrap': False},
     'nhl': {'start': 10, 'wrap': True}
 }
+
+def _rate_limit_pq(pq_input, sleep=3.5):
+    ret = pq(pq_input)
+    time.sleep(sleep)
+    return ret
 
 
 def _todays_date():
@@ -158,12 +164,10 @@ def _parse_field(parsing_scheme, html_data, field, index=0, strip=False,
                  secondary_index=None):
     """
     Parse an HTML table to find the requested field's value.
-
     All of the values are passed in an HTML table row instead of as individual
     items. The values need to be parsed by matching the requested attribute
     with a parsing scheme that sports-reference uses to differentiate stats.
     This function returns a single value for the given attribute.
-
     Parameters
     ----------
     parsing_scheme : dict
@@ -195,7 +199,6 @@ def _parse_field(parsing_scheme, html_data, field, index=0, strip=False,
         doesn't have all of the intended information, and the requested index
         isn't valid, causing the value to be None. Instead, a secondary index
         could be checked prior to returning None.
-
     Returns
     -------
     string
@@ -317,7 +320,7 @@ def _pull_page(url=None, local_file=None):
         with open(local_file, 'r', encoding='utf8') as filehandle:
             return pq(filehandle.read())
     if url:
-        return pq(url)
+        return _rate_limit_pq(url)
     raise ValueError('Expected either a URL or a local data file!')
 
 

--- a/tests/integration/boxscore/test_mlb_boxscore.py
+++ b/tests/integration/boxscore/test_mlb_boxscore.py
@@ -183,9 +183,9 @@ class TestMLBBoxscore:
     def test_mlb_boxscore_string_representation(self):
         expected = ('Boxscore for San Francisco Giants at '
                     'Los Angeles Angels (Monday, August 17, 2020)')
-
+        print('expected: ', expected)
         boxscore = Boxscore(BOXSCORE)
-
+        print('repr: ', boxscore.__repr__())
         assert boxscore.__repr__() == expected
 
 


### PR DESCRIPTION
SportsReference enforces a rate limit of 20 requests per minute. This PR adds time.sleep after every url request to avoid `urllib.error.HTTPError: HTTP Error 429: Too Many Requests`
